### PR TITLE
blocks: always generate a childMarkdownRemark node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -57,7 +57,9 @@ exports.onCreateNode = ({
       })
 
       node.blocks.forEach((block, i) => {
-        if (!block.content) return
+        if (!block.content) {
+          block.content = ""
+        }
         const blockNode = {
           id: `${node.id} block ${i} markdown`,
           parent: markdownHost.id,


### PR DESCRIPTION
due to the way we have to query for childMarkdownRemark, each block node needs to generate a corresponding childMarkdownRemark node.