### PR TITLE
Added the ability to toggle the header icon on or off using the theme

### DIFF
--- a/content/settings/theme.json
+++ b/content/settings/theme.json
@@ -19,7 +19,8 @@
     "overline": true,
     "transparent": true,
     "height": "3.25rem",
-    "underline": true
+    "underline": true,
+    "showIcon": true
   },
   "hero": {
     "image": "../images/cafe.jpg",

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Wrapper } from "./style"
-import { Coffee } from "styled-icons/boxicons-regular"
+import { Coffee } from "styled-icons/boxicons-regular" // To change the icon, change this import and the usage below.
 import styled, { css } from "styled-components"
 import { transparentize } from "polished"
 import { Nav } from "./nav"
@@ -15,7 +15,7 @@ export const Header = styled(({ siteTitle, ...styleProps }) => {
           <HeaderWrapper>
             <SiteTitle>
               <SiteLink to="/">
-                <Coffee />
+                {theme.header.showIcon && <Coffee />}
                 {siteTitle}
               </SiteLink>
             </SiteTitle>

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -124,6 +124,7 @@ export const globalThemeFragment = graphql`
       underline
       transparent
       height
+      showIcon
     }
     menu {
       style
@@ -218,6 +219,11 @@ export const ThemeForm = {
           parse(value) {
             return value || ""
           },
+        },
+        {
+          label: "Show Icon",
+          name: "showIcon",
+          component: "toggle",
         },
       ],
     },


### PR DESCRIPTION
This addresses this old issue: #16

I added a toggle to allow users to toggle off the icon that is shown in the header by default. Along with the pull request to disable the dark mode toggle (https://github.com/tinacms/tina-starter-grande/pull/65), this gives users full control over what is shown in the header.

Here's what the home page looks like without the header icon.
![showIcon-off](https://user-images.githubusercontent.com/11086549/112735116-66f7f000-8f07-11eb-92f0-ed5df91044a2.jpg)

Here's the theme toggle.
![showIcon-toggle](https://user-images.githubusercontent.com/11086549/112735114-60697880-8f07-11eb-94f8-e3b0bc4d54f8.jpg)
